### PR TITLE
added redirect from / to /time_tracker.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=./time_tracker.html" />
+  </head>
+</html>


### PR DESCRIPTION
I'm hosting Task-Time-Tracker on github pages and would like be able to type in https://danieljdufour.com/Task-Time-Tracker instead of https://danieljdufour.com/Task-Time-Tracker/time_tracker.html.  The new index.html file redirects the user to time_tracker.html.  I'm sorry if I missed any info or submitted this PR to the wrong branch!  Happy to discuss.  Thank you for your consideration.